### PR TITLE
Fix page refreshing if you press enter while selecting a team to highlight

### DIFF
--- a/client/src/Matches.js
+++ b/client/src/Matches.js
@@ -22,7 +22,8 @@ class Matches extends React.Component {
                 <h2>Matches</h2>
                 {this.props.event_code ? [
 
-				<form className="searchTeam">
+				<form className="searchTeam" onSubmit={event => {event.preventDefault()}}> 
+				{/* The onSubmit event is passed to event.preventDefault() to stop the page from refreshing when you press enter accidentally */}
 					<label>Search Team: </label>
 					<input type="text" id="team_to_search" name="team_to_search" onChangeCapture={this.onTeamChange} />
 				</form>,


### PR DESCRIPTION
Before, on the Schedule tab when you pressed the Enter key while inside of the input box, the page would refresh as HTML thought you were submitting the form. That has been fixed and pressing Enter should do nothing