### PR TITLE
solve issue #20

### DIFF
--- a/client/src/DataSpitter.js
+++ b/client/src/DataSpitter.js
@@ -18,7 +18,7 @@ class DataSpitter extends React.Component {
 		<input type="text" id="teamToSearch" name="teamToSearch" value={this.team_to_search} onChange={this.onTeamChange} size="5"/>
 		<label htmlFor="teamToSearch"> {this.state.valid_number ? "valid - hit enter to submit" : "invalid"} </label>
 </form>
-	    {this.props.event_code && this.props.data_spitter_output ? (
+	    {this.props.event_code && (this.props.data_spitter_output && this.props.data_spitter_output.length > 0) ? (
 		<table>
 		  <thead>
 		    <tr>

--- a/client/src/NextMatch.js
+++ b/client/src/NextMatch.js
@@ -17,7 +17,7 @@ class NextMatch extends React.Component {
 		    <label htmlFor="specificAllToggle">Only current event</label>
 		  </div>
 		  
-		  {this.props.event_code && this.props.next_match_info ? (
+		  {this.props.event_code && (this.props.next_match_info && this.props.next_match_info.length > 0) ? (
 		  <table>
 		    <thead>
 		      <tr>

--- a/client/src/Strategy.js
+++ b/client/src/Strategy.js
@@ -156,7 +156,7 @@ class Strategy extends React.Component {
     getScoutingOutput(event_code, specific_scouting_output) {
 	//console.log(specific_scouting_output);
 	axios.get(serverURL + "/api/getScoutingOutput?event_code=" + event_code + "&specific_scouting_output=" + specific_scouting_output)
-	    .then((response) => this.setState({ scouting_output: response.data.data }));
+	    .then((response) => this.setState({ scouting_output: response.data.data }, ));
     }
     
     // get the picklist


### PR DESCRIPTION
#20 `next_match_info` and `data_spitter_output` are both set to empty arrays and empty arrays evaluate to true when used in logic operators. This posed an issue because before refresh could assign these variables to undefined the headers would appear. This was fixed by adding a and operator to  `next_match_info` and `data_spitter_output` in the ternary operator. This and operator checked the length of the arrays and if it was zero it would evaluate to false making the entire section of the ternary operator false causing it not to print the headers.