### PR TITLE
Add DataTable to allow concise use of tables in tabs.

### DIFF
--- a/client/src/CustomQuery.js
+++ b/client/src/CustomQuery.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import DataTable from './DataTable.js';
 
 class CustomQuery extends React.Component {
     constructor(props){
@@ -18,24 +19,7 @@ class CustomQuery extends React.Component {
 		  <div/>
 		  <input type="submit" value="Query"/>
 		</form>
-		{this.props.results ? (
-			<div>
-			  <table>
-			    <thead>
-			      <tr>
-				{Object.keys(this.props.results[0]).map((key) =>
-									<th key={key}>{key}</th>)}
-			      </tr>
-			    </thead>
-			    <tbody>
-			{this.props.results.map((result, index) =>
-						<tr key={index}>
-						{Object.keys(result).map(header => 
-									 <td key={result[header]}>{result[header]}</td>)}
-						</tr>)}
-			    </tbody>
-			  </table>
-			</div>) : console.log("nothing") }
+		<DataTable data={this.props.results}/>
 		<h3>Fun queries/reference:</h3>
 		<p>Manually enter data (after quick adding match from command line). Fill blanks with right info</p>
 		<code>   INSERT INTO alliance_member_outcome VALUES ((SELECT a.alliance_id FROM frc_match m INNER JOIN alliance a ON a.match_id = m.match_id WHERE m.match_type =     AND m.match_number =    AND m.event_code =           AND a.alliance_colour =     ),         ;</code>

--- a/client/src/DataTable.js
+++ b/client/src/DataTable.js
@@ -3,28 +3,34 @@ import React from 'react';
 class DataTable extends React.Component {
     constructor(props){
 	super(props);
+	//props: data, displayed in tbody, headers (optional) for labelling
 	
     }
 
     render() {
-        return (
-		{this.props.results? (
-			<div>
+        return ( <div>
+		{this.props.data ? (
 			  <table>
 			    <thead>
-			      <tr>
-				{Object.keys(this.props.results[0]).map((key) =>
-									<th key={key}>{key}</th>)}
+                  <tr>
+				  {this.props.headers === null ? void 0 : Object.keys(this.props.data[0]).map((key) =>
+					<th key={key}>{key}</th>) 
+				}
 			      </tr>
 			    </thead>
+
 			    <tbody>
-			{this.props.results.map((result, index) =>
+				{this.props.data.map((result, index) =>
 						<tr key={index}>
 						{Object.keys(result).map(header => 
 									 <td key={result[header]}>{result[header]}</td>)}
 						</tr>)}
 			    </tbody>
+
 			  </table>
-			</div>) : console.log("nothing") }
+			) : console.log("nothing") }
+			</div>
         )
-    }
+	}
+}
+export default DataTable;


### PR DESCRIPTION
Not applied to most tabs, because it makes specially formatting data and rearranging columns much harder and reduces readability, in my opinion.